### PR TITLE
Improve encoding generation performance by not duplicating data obj

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "test": "test"
   },
   "scripts": {
+    "build": "gulp build",
+    "watch": "gulp build watch",
     "deploy": "npm run lint && npm run test && scripts/deploy.sh",
     "lint": "gulp jshint",
     "test": "gulp t"

--- a/src/gen/encodings.js
+++ b/src/gen/encodings.js
@@ -28,13 +28,16 @@ function genEncodingsFromEncs(output, enc, stats, opt) {
   getMarktypes(enc, stats, opt)
     .forEach(function(markType) {
       var e = vl.duplicate({
-          data: opt.data,
-          marktype: markType,
+          // Clone config & encoding to unique objects
           encoding: enc,
           config: opt.config
         }),
         encoding = finalTouch(e, stats, opt),
         score = rank.encoding(encoding, stats, opt);
+
+      e.marktype = markType;
+      // Data object is the same across charts: pass by reference
+      e.data = opt.data;
 
       encoding._info = score;
       output.push(encoding);


### PR DESCRIPTION
Profiling data load with a 1mb csv file shows 5 seconds of computing time is needed to generate encodings:

![image](https://cloud.githubusercontent.com/assets/442115/10491178/2611d9ea-7273-11e5-8925-8b9bed5b64ce.png)

Of this 5 seconds, half of the time is taken up by the `forEach` that calls `vl.duplicate`:

![image](https://cloud.githubusercontent.com/assets/442115/10491193/4670f86a-7273-11e5-95d9-dca469675100.png)

By omitting the `.data` property from the object passed to `vl.duplicate`, the total run time for encoding generation drops to 2.8 seconds:

![image](https://cloud.githubusercontent.com/assets/442115/10491208/5f1cdd5c-7273-11e5-82a4-8f14659e3237.png)

The remaining time is predominately the `merge` function within vega lite, `_.cloneDeep`, and other merge and clone methods; `vl.duplicate` is still 500ms of the total processing time of a full data load and data render cycle, but by simply removing the data object from this instance of duplication we can notably increase the performance of the cluster generation, and reduce the memory overhead.

Since the data object should be consistent & immutable across the different charts, passing data by reference rather than by duplication is not just efficient, but desirable.
