### PR TITLE
Do not repeatedly re-extend opt object with marktype information

### DIFF
--- a/src/gen/encodings.js
+++ b/src/gen/encodings.js
@@ -9,6 +9,7 @@ var vl = require('vega-lite'),
 module.exports = genEncodingsFromFields;
 
 function genEncodingsFromFields(output, fields, stats, opt, nested) {
+  // opt must be augmented before being passed to genEncs or getMarktypes
   opt = vl.schema.util.extend(opt||{}, consts.gen.encodings);
   var encs = genEncs([], fields, stats, opt);
 

--- a/src/gen/encs.js
+++ b/src/gen/encs.js
@@ -2,7 +2,6 @@
 require('../globals');
 
 var vl = require('vega-lite'),
-  consts = require('../consts'),
   genMarkTypes = require('./marktypes'),
   isDimension = vl.field.isDimension,
   isMeasure = vl.field.isMeasure;
@@ -168,7 +167,6 @@ genEncs.isAggrWithAllDimOnFacets = function (enc) {
 
 
 function genEncs(encs, fields, stats, opt) {
-  opt = vl.schema.util.extend(opt||{}, consts.gen.encodings);
   // generate a collection vega-lite's enc
   var tmpEnc = {};
 

--- a/src/gen/marktypes.js
+++ b/src/gen/marktypes.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var vl = require('vega-lite'),
-  consts = require('../consts'),
   isDimension = vl.field.isDimension,
   isOrdinalScale = vl.field.isOrdinalScale;
 
@@ -17,13 +16,9 @@ var marksRule = vlmarktypes.rule = {
 };
 
 function getMarktypes(enc, stats, opt) {
-  opt = vl.schema.util.extend(opt||{}, consts.gen.encodings);
-
-  var markTypes = opt.marktypeList.filter(function(markType){
+  return opt.marktypeList.filter(function(markType){
     return vlmarktypes.satisfyRules(enc, markType, stats, opt);
   });
-
-  return markTypes;
 }
 
 vlmarktypes.satisfyRules = function (enc, markType, stats, opt) {

--- a/test/gen/encs.spec.js
+++ b/test/gen/encs.spec.js
@@ -7,13 +7,24 @@ var expect = require('chai').expect,
   fixture = require('../fixture');
 
 var genEncs = require('../../src/gen/encs');
+var consts = require('../../src/consts');
 
 describe('cp.gen.encs()', function () {
-   describe('#', function () {
-    var f = fixture['#'];
+  var opt;
+
+  beforeEach(function() {
+    opt = vl.schema.util.extend({}, consts.gen.encodings);
+  });
+
+  describe('#', function () {
+    var f;
+
+    beforeEach(function() {
+      f = fixture['#'];
+    });
 
     it('should generate one encs', function() {
-      var encs = genEncs([], f.fields, f.stats);
+      var encs = genEncs([], f.fields, f.stats, opt);
       expect(encs.length).to.eql(1);
       expect(encs[0].x).to.be.ok;
     });
@@ -24,10 +35,12 @@ describe('cp.gen.encs()', function () {
   });
 
   describe('#xB(Q)', function() {
-    var f = fixture['#xB(Q)'];
-    var encs = genEncs([], f.fields, f.stats);
-
-    var encShorthands = encs.map(vl.enc.shorthand);
+    var f, encs, encShorthands;
+    beforeEach(function() {
+      f = fixture['#xB(Q)'];
+      encs = genEncs([], f.fields, f.stats, opt);
+      encShorthands = encs.map(vl.enc.shorthand);
+    });
 
     it('should show only vertical bar/plots', function() {
       expect(encShorthands.indexOf('x=count_*,Q|y=bin_2,Q')).to.equal(-1);
@@ -37,10 +50,12 @@ describe('cp.gen.encs()', function () {
   });
 
   describe('#xT', function() {
-    var f = fixture['#xT'];
-    var encs = genEncs([], f.fields, f.stats);
-
-    var encShorthands = encs.map(vl.enc.shorthand);
+    var f, encs, encShorthands;
+    beforeEach(function() {
+      f = fixture['#xT'];
+      encs = genEncs([], f.fields, f.stats, opt);
+      encShorthands = encs.map(vl.enc.shorthand);
+    });
 
     // console.log('#xT', encs.map(vl.enc.shorthand));
 
@@ -51,10 +66,12 @@ describe('cp.gen.encs()', function () {
   });
 
   describe('#xYR(T)', function() {
-    var f = fixture['#xYR(T)'];
-    var encs = genEncs([], f.fields, f.stats);
-
-    var encShorthands = encs.map(vl.enc.shorthand);
+    var f, encs, encShorthands;
+    beforeEach(function() {
+      f = fixture['#xYR(T)'];
+      encs = genEncs([], f.fields, f.stats, opt);
+      encShorthands = encs.map(vl.enc.shorthand);
+    });
 
     // console.log('#xYR(T)', encs.map(vl.enc.shorthand));
 
@@ -65,10 +82,12 @@ describe('cp.gen.encs()', function () {
   });
 
   describe('QxT', function () {
-    var f = fixture['QxT'];
-    var encs = genEncs([], f.fields, f.stats);
-
-    var encShorthands = encs.map(vl.enc.shorthand);
+    var f, encs, encShorthands;
+    beforeEach(function() {
+      f = fixture['QxT'];
+      encs = genEncs([], f.fields, f.stats, opt);
+      encShorthands = encs.map(vl.enc.shorthand);
+    });
     it('should show only vertical bar/plots', function() {
       expect(encShorthands.indexOf('x=1,Q|y=2,T')).to.equal(-1);
       expect(encShorthands.indexOf('x=2,T|y=1,Q')).to.gt(-1);
@@ -86,21 +105,24 @@ describe('cp.gen.encs()', function () {
   //     2: {cardinality: 10}
   //   };
 
-  //   var encs = genEncs([], fields, stats);
+  //   var encs = genEncs([], fields, stats, opt);
   //   console.log('QxC', encs);
   // });
 
   // describe('QxA(Q),', function() {
   //   var f = fixture['OxA(Q)'];
-  //   var encs = genEncs([], f.fields, f.stats);
+  //   var encs = genEncs([], f.fields, f.stats, opt);
   //   console.log('QxA(Q)', encs.map(vl.enc.shorthand));
   // });
 
   describe('OxOxQ', function () {
-    var f = fixture.OxOxQ;
+    var f;
+    beforeEach(function() {
+      f = fixture.OxOxQ;
+    });
 
     it('without stats about occlusion, it should not include charts with both O\'s on axes', function() {
-      var encs = genEncs([], f.fields, f.stats);
+      var encs = genEncs([], f.fields, f.stats, opt);
 
       var filtered = encs.filter(function(enc){
         return enc.x.type === 'O' && enc.y.type === 'O';
@@ -111,10 +133,13 @@ describe('cp.gen.encs()', function () {
   });
 
   describe('OxOxA(Q)', function () {
-    var f = fixture['OxOxA(Q)'];
+    var f;
+    beforeEach(function() {
+      f = fixture['OxOxA(Q)'];
+    });
 
     it('without stats about occlusion, it should include charts with both O\'s on axes', function() {
-      var encs = genEncs([], f.fields, f.stats);
+      var encs = genEncs([], f.fields, f.stats, opt);
 
       // console.log('OxOxA(Q)', encs);
 
@@ -127,12 +152,15 @@ describe('cp.gen.encs()', function () {
   });
 
   describe('OxA(Q)xA(Q)', function () {
-    var f = fixture['OxA(Q)xA(Q)'],
-      fields = f.fields,
+    var f, fields, stats;
+    beforeEach(function() {
+      f = fixture['OxA(Q)xA(Q)'];
+      fields = f.fields;
       stats = f.stats;
+    });
 
     it('should not include charts with O on row/col except with text', function() {
-      var encs = genEncs([], fields, stats);
+      var encs = genEncs([], fields, stats, opt);
 
       expect(encs.filter(function(enc) {
         var rowIsO = enc.row && enc.row.type==='O',
@@ -142,9 +170,8 @@ describe('cp.gen.encs()', function () {
     });
 
     it('should include charts with O on row/col when omit flag is disabled', function() {
-      var encs = genEncs([], fields, stats, {
-        omitNonTextAggrWithAllDimsOnFacets: false
-      });
+      opt.omitNonTextAggrWithAllDimsOnFacets = false;
+      var encs = genEncs([], fields, stats, opt);
       expect(encs.filter(function(enc) {
         return (enc.row && enc.row.type==='O') ||
           (enc.col && enc.col.type==='O');

--- a/test/gen/marktypes.spec.js
+++ b/test/gen/marktypes.spec.js
@@ -5,15 +5,26 @@ var expect = require('chai').expect,
   fixture = require('../fixture');
 
 // var dataB = require("../data/birdstrikes.json");
+var consts = require('../../src/consts');
 var getMarkTypes = require('../../src/gen/marktypes');
 
 describe('cp.gen.marktypes()', function(){
+  var opt;
+
+  beforeEach(function() {
+    opt = vl.schema.util.extend({}, consts.gen.encodings);
+  });
+
   describe('#', function () {
-    var f = fixture['#'];
+    var f;
+
+    beforeEach(function() {
+      f = fixture['#'];
+    });
 
     it('should generate point and bar', function() {
       var enc = {x: f.fields[0]},
-        markTypes = getMarkTypes(enc, f.stats);
+        markTypes = getMarkTypes(enc, f.stats, opt);
 
       expect(markTypes.length).to.eql(2);
       expect(markTypes).to.eql(['point', 'bar']);
@@ -21,8 +32,11 @@ describe('cp.gen.marktypes()', function(){
   });
 
   describe('1Q', function () {
-    var enc = {"x": {"name": "Cost__Total_$","type": "Q"}};
-    var marktypes = getMarkTypes(enc);
+    var enc, marktypes;
+    beforeEach(function() {
+      enc = {"x": {"name": "Cost__Total_$","type": "Q"}};
+      marktypes = getMarkTypes(enc, {}, opt);
+    });
     it('should contain tick', function () {
       expect(marktypes.indexOf('tick')).to.gt(-1);
     });
@@ -55,7 +69,8 @@ describe('cp.gen.marktypes()', function(){
           "x": {"name": "Cost__Total_$","type": "Q","aggregate": "avg"},
           "y": {"selected": undefined,"name": "Aircraft__Airline_Operator","type": "O"}
         };
-        var marktypes = getMarkTypes(enc);
+
+        var marktypes = getMarkTypes(enc, {}, opt);
         expect(marktypes.indexOf('bar')).to.equal(-1);
       });
     });
@@ -67,7 +82,7 @@ describe('cp.gen.marktypes()', function(){
           "x": {"name": "Cost__Total_$","type": "Q","aggregate": "sum"},
           "y": {"selected": undefined,"name": "Aircraft__Airline_Operator","type": "O"}
         };
-        var marktypes = getMarkTypes(enc);
+        var marktypes = getMarkTypes(enc, {}, opt);
         expect(marktypes.indexOf('bar')).to.gt(-1);
       });
     });
@@ -81,7 +96,7 @@ describe('cp.gen.marktypes()', function(){
     it('should be generated', function () {
       var shorthand = 'row=1,O|text=avg_2,Q',
         enc = vl.enc.fromShorthand(shorthand),
-        marktypes = getMarkTypes(enc);
+        marktypes = getMarkTypes(enc, {}, opt);
       expect(marktypes.indexOf('text')).to.gt(-1);
     });
 
@@ -99,7 +114,7 @@ describe('cp.gen.marktypes()', function(){
         }
       };
 
-      var marktypes = getMarkTypes(enc);
+      var marktypes = getMarkTypes(enc, {}, opt);
 
       expect(marktypes.indexOf('text')).to.equal(-1);
     });


### PR DESCRIPTION
`opt = vl.schema.util.extend(opt||{}, consts.gen.encodings);` is called within `encodings.js`'s `genEncodingsFromFields` method. The same extend call is present in two other methods that `genEncodingsFromFields` calls, `getEncs` and `getMarktypes`. There is no benefit to repeating the `vl.schema.util.extend` call, as the `opt` object is not being mutated by any of these subsequent methods: repeating the extension just makes each iteration take longer.

`genEncodingsFromFields` takes ~80ms each time it runs, for a total of almost a second when loading a large (~1mb) CSV dataset: a significant proportion of that processing time is tied up in calls to `vl.schema.util.extend`.

![image](https://cloud.githubusercontent.com/assets/442115/10495447/e79ca746-7289-11e5-938a-bbee1e816fba.png)

Removing the redundant calls drops the runtime for `genEncodingsFromFields` to ~25ms:

![image](https://cloud.githubusercontent.com/assets/442115/10495525/6302a85e-728a-11e5-9694-f3d7b64a3c75.png)

The initial extension is still slow, but removing the subsequent calls keeps things moving after that.

Tests have been updated to take a configured options object, and all test variable declarations have been moved to mocha `beforeEach` functions per mocha best practices.