### PR TITLE
Quick fix for making genSpecs work.

### DIFF
--- a/src/gen/specs.ts
+++ b/src/gen/specs.ts
@@ -24,7 +24,7 @@ export default function genSpecsFromFieldDefs(output, fieldDefs, stats, opt: Spe
   } else {
     return encodings.reduce(function(list, encoding) {
       return genSpecsFromEncodings(list, encoding, stats, opt);
-    }, []);
+    }, output);
   }
 }
 


### PR DESCRIPTION
@yhoonkim  Ideally, I should separate this method into two methods (one with nested logic) and one with non-nested, but this should be sufficient for you for now.  


Note that your original fix, as discussed in https://github.com/uwdata/vega-lite-space/issues/2#issuecomment-172264981

```js
var specs = encodings.reduce(function(list, encoding) {
      return genSpecsFromEncodings(list, encoding, stats, opt);
}, []);
output.push(specs);
return output;
```

would produce an array of arrays of specs, rather than an array of specs.  