### PR TITLE
Scale can't be with bin.

### DIFF
--- a/src/gen/scales.ts
+++ b/src/gen/scales.ts
@@ -13,7 +13,7 @@ export default function genScales(output, fieldDefs: SchemaField[], opt: ScaleOp
       return;
     }
 
-    if (fieldDefs[i].type === Type.QUANTITATIVE && opt.rescaleQuantitative) {
+    if (fieldDefs[i].type === Type.QUANTITATIVE && opt.rescaleQuantitative && !(fieldDefs[i].bin)) {
       // if quantitative and we have rescaleQuantitative, generate different scales
       opt.rescaleQuantitative.forEach(function(scaleType) {
         // clone to prevent side effect on the original data

--- a/test/gen/scales.test.ts
+++ b/test/gen/scales.test.ts
@@ -5,14 +5,10 @@ import {expect} from 'chai';
 describe('cp.gen.scales()', function () {
   it('should correctly generate fieldSets with scale variation', function() {
     const fields = [0,1,2,3].map(function(i) {
-      var field = {
+      return {
         field: 'f' + i,
-        type: i < 3 ? Type.QUANTITATIVE : Type.ORDINAL // 2xQ, 2xO
+        type: i < 2 ? Type.QUANTITATIVE : Type.ORDINAL // 2xQ, 2xO
       };
-      if (i === 2)
-          field["bin"] = true;
-
-      return field;
     });
     const output = genScales([], fields, {rescaleQuantitative: [undefined, 'log']});
     expect(output.length).to.equal(4); // only 0 and 1 get rescaled 2x2 = 4
@@ -26,4 +22,18 @@ describe('cp.gen.scales()', function () {
     expect(output[3][0].scale.type).to.equal('log');
     expect(output[3][1].scale.type).to.equal('log');
   });
+
+  it('should not generate scale variation for bin', function() {
+    const fields = [{
+      field: 'f',
+      type: Type.QUANTITATIVE,
+      bin: true
+    }];
+
+    const output = genScales([], fields, {rescaleQuantitative: [undefined, 'log']});
+    expect(output.length).to.equal(1); // can't be applied log scale.
+
+
+  });
+
 });

--- a/test/gen/scales.test.ts
+++ b/test/gen/scales.test.ts
@@ -5,14 +5,18 @@ import {expect} from 'chai';
 describe('cp.gen.scales()', function () {
   it('should correctly generate fieldSets with scale variation', function() {
     const fields = [0,1,2,3].map(function(i) {
-      return {
+      var field = {
         field: 'f' + i,
-        type: i < 2 ? Type.QUANTITATIVE : Type.ORDINAL // 2xQ, 2xO
+        type: i < 3 ? Type.QUANTITATIVE : Type.ORDINAL // 2xQ, 2xO
       };
+      if (i === 2)
+          field["bin"] = true;
+
+      return field;
     });
     const output = genScales([], fields, {rescaleQuantitative: [undefined, 'log']});
-    expect(output.length).to.equal(4); // only 1 and 2 get rescaled 2x2 = 4
-    
+    expect(output.length).to.equal(4); // only 0 and 1 get rescaled 2x2 = 4
+
     // output[0]'s scale: default, default
     // output[1]'s scale: default, log
     expect(output[1][1].scale.type).to.equal('log');


### PR DESCRIPTION
@kanitw I excluded the case that field has ``scale`` and ``bin``.