### PR TITLE
Prevented bar from log scale. (#153)

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -118,6 +118,8 @@ export interface SpecOption {
   omitShapeWithTimeDimension?: boolean;
   /** Do not use bar\'s size. */
   omitSizeOnBar?: boolean; // FIXME: remove
+  /** Do not use bar with log scale. */
+  omitLogScaleOnBar?: boolean;
   /** Do not stack bar chart with average. */
   omitStackedAverage?: boolean; // FIXME: change to omit non-sum stacked
   /**
@@ -149,6 +151,7 @@ export const DEFAULT_SPEC_OPTION: SpecOption = {
   omitShapeWithBin: true,
   omitShapeWithTimeDimension: true,
   omitSizeOnBar: true,
+  omitLogScaleOnBar: true,
   omitStackedAverage: true,
   omitTranspose: true,
 };

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -119,7 +119,7 @@ export interface SpecOption {
   /** Do not use bar\'s size. */
   omitSizeOnBar?: boolean; // FIXME: remove
   /** Do not use bar with log scale. */
-  omitLogScaleOnBar?: boolean;
+  omitLengthForLogScale?: boolean;
   /** Do not stack bar chart with average. */
   omitStackedAverage?: boolean; // FIXME: change to omit non-sum stacked
   /**
@@ -151,7 +151,7 @@ export const DEFAULT_SPEC_OPTION: SpecOption = {
   omitShapeWithBin: true,
   omitShapeWithTimeDimension: true,
   omitSizeOnBar: true,
-  omitLogScaleOnBar: true,
+  omitLengthForLogScale: true,
   omitStackedAverage: true,
   omitTranspose: true,
 };

--- a/src/gen/marks.ts
+++ b/src/gen/marks.ts
@@ -88,6 +88,14 @@ export namespace rule {
 
     if (opt.omitSizeOnBar && encoding.size !== undefined) return false;
 
+
+    if (opt.omitLogScaleOnBar) {
+      if (encoding.x && encoding.x.scale && encoding.x.scale.type === "log" ) return false;
+      if (encoding.y && encoding.y.scale && encoding.y.scale.type === "log" ) return false;
+    }
+
+
+
     // FIXME actually check if there would be occlusion #90
     // need to aggregate on either x or y
 
@@ -104,7 +112,7 @@ export namespace rule {
       if (eitherXorYisDimOrNull) {
         var aggregate = encoding.x.aggregate || encoding.y.aggregate;
 
-        // TODO: revise 
+        // TODO: revise
         return !(opt.omitStackedAverage && aggregate ==='mean' && encoding.color);
       }
     }

--- a/src/gen/marks.ts
+++ b/src/gen/marks.ts
@@ -89,7 +89,7 @@ export namespace rule {
     if (opt.omitSizeOnBar && encoding.size !== undefined) return false;
 
 
-    if (opt.omitLogScaleOnBar) {
+    if (opt.omitLengthForLogScale) {
       if (encoding.x && encoding.x.scale && encoding.x.scale.type === "log" ) return false;
       if (encoding.y && encoding.y.scale && encoding.y.scale.type === "log" ) return false;
     }
@@ -136,6 +136,10 @@ export namespace rule {
     if (!facetsRule(encoding, stats, opt)) return false;
 
     if (!line(encoding, stats, opt)) return false;
+    if (opt.omitLengthForLogScale) {
+      if (encoding.x && encoding.x.scale && encoding.x.scale.type === "log" ) return false;
+      if (encoding.y && encoding.y.scale && encoding.y.scale.type === "log" ) return false;
+    }
 
     return !(opt.omitStackedAverage && encoding.y.aggregate ==='mean' && encoding.color);
   }

--- a/test/gen/marktypes.test.ts
+++ b/test/gen/marktypes.test.ts
@@ -84,8 +84,17 @@ describe('cp.gen.marks()', function(){
         expect(marks.indexOf(BAR)).to.gt(-1);
       });
     });
+    describe('with log scale', function () {
+      it('should not be generated', function () {
+        var encoding = {
+          'x': { 'fiel': 'Cost__Total_$', 'type': QUANTITATIVE, 'scale': { 'type' : 'log' } },
+          'y': { 'field': 'Aircraft__Airline_Operator', 'type': ORDINAL }
+        };
+        var marks = getMarks(encoding, {}, opt);
+        expect(marks.indexOf(BAR)).to.equal(-1);
+      });
+    });
   });
-
   describe('line/area', function () {
     // TODO
   });

--- a/test/gen/marktypes.test.ts
+++ b/test/gen/marktypes.test.ts
@@ -3,8 +3,8 @@ import {fixture} from '../fixture';
 import getMarks from '../../src/gen/marks';
 import {DEFAULT_SPEC_OPTION} from '../../src/consts';
 import * as vlShorthand from 'vega-lite/src/shorthand';
-import {BAR, POINT, TEXT} from 'vega-lite/src/mark';
-import {QUANTITATIVE, ORDINAL} from 'vega-lite/src/type';
+import {BAR, POINT, TEXT, AREA} from 'vega-lite/src/mark';
+import {QUANTITATIVE, ORDINAL, TEMPORAL} from 'vega-lite/src/type';
 
 describe('cp.gen.marks()', function(){
   var opt;
@@ -96,6 +96,16 @@ describe('cp.gen.marks()', function(){
     });
   });
   describe('line/area', function () {
+    describe('with log scale', function () {
+      it('should not be generated', function () {
+        var encoding = {
+          'x': { 'field': 'Year', 'type': TEMPORAL },
+          'y': { 'field': 'Weight_in_lbs', 'type': QUANTITATIVE, 'scale': { 'type': 'log' }, 'aggregate': 'sum' }
+          };
+          var marks = getMarks(encoding, {}, opt);
+        expect(marks.indexOf(AREA)).to.equal(-1);
+      });
+    });
     // TODO
   });
 


### PR DESCRIPTION
Added `omitLogScaleOnBar` option. Default is `true`.